### PR TITLE
 Option to read wildcards for replay of many beads

### DIFF
--- a/ipi/engine/motion/replay.py
+++ b/ipi/engine/motion/replay.py
@@ -8,12 +8,15 @@
 
 
 import time
+import os
+from fnmatch import fnmatch
 
 from ipi.engine.motion import Motion
 from ipi.utils.softexit import softexit
-from ipi.utils.io import read_file
+from ipi.utils.io import read_file, read_file_raw
 from ipi.utils.io.inputs.io_xml import xml_parse_file
 from ipi.utils.units import unit_to_internal
+from ipi.utils.messages import verbosity, info
 
 
 __all__ = ["Replay"]
@@ -58,7 +61,34 @@ class Replay(Motion):
             raise ValueError(
                 "Replay can only read from PDB or XYZ files -- or a single frame from a CHK file"
             )
-        self.rfile = open(self.intraj.value, "r")
+        # Posibility to read beads from separate XYZ files by a wildcard
+        if '*' in self.intraj.value:
+            infilelist = []
+            for file in sorted(os.listdir('.')):
+                if fnmatch(file, self.intraj.value):
+                    infilelist.append(file)
+            # determine bead numbers in input files
+            bead_map_list = []
+            for file in infilelist:
+                fdin = open(file, 'r')
+                rr = read_file_raw(self.intraj.mode, fdin)
+                metainfo = rr['comment'].split()
+                for i, word in enumerate(metainfo):
+                    if word == 'Bead:':
+                        bead_map_list.append(int(metainfo[i+1]))
+                fdin.close()
+            # check that beads are continuous (no files missing)
+            if sorted(bead_map_list) != list(range(len(bead_map_list))):
+                raise ValueError(
+                    "Provided trajectory files have non-continuous "
+                    "range of bead indices."
+                )
+            # sort the list of files according to their bead indices
+            infilelist_sorted, _ = zip(*sorted(zip(infilelist, bead_map_list),
+                                       key = lambda t: t[1]))
+            self.rfile = [open(f, 'r') for f in infilelist_sorted]
+        else:   # no wildcard
+            self.rfile = open(self.intraj.value, "r")
         self.rstep = 0
 
     def step(self, step=None):
@@ -70,10 +100,21 @@ class Replay(Motion):
 
         while True:
             self.rstep += 1
+            # If wildcard is used, check that it is consistent with Nbeads
+            if '*' in self.intraj.value and len(self.rfile) != len(self.beads):
+                info(
+                    "Error: if a wildcard is used for replay, then "
+                    "the number of files should be equal to the number of beads.",
+                    verbosity.low
+                )
+                softexit.trigger(" # Error in replay input.")
             try:
                 if self.intraj.mode == "xyz":
-                    for b in self.beads:
-                        myframe = read_file("xyz", self.rfile)
+                    for bindex, b in enumerate(self.beads):
+                        if '*' in self.intraj.value:    # wildcarded filename
+                            myframe = read_file("xyz", self.rfile[bindex])
+                        else:
+                            myframe = read_file("xyz", self.rfile)
                         myatoms = myframe["atoms"]
                         mycell = myframe["cell"]
                         myatoms.q *= unit_to_internal("length", self.intraj.units, 1.0)
@@ -81,8 +122,11 @@ class Replay(Motion):
                         b.q[:] = myatoms.q
                     self.cell.h[:] = mycell.h
                 elif self.intraj.mode == "pdb":
-                    for b in self.beads:
-                        myatoms, mycell = read_file("pdb", self.rfile)
+                    for bindex, b in enumerate(self.beads):
+                        if '*' in self.intraj.value:    # wildcarded filename
+                            myatoms, mycell = read_file("pdb", self.rfile[bindex])
+                        else:
+                            myatoms, mycell = read_file("pdb", self.rfile)
                         myatoms.q *= unit_to_internal("length", self.intraj.units, 1.0)
                         mycell.h *= unit_to_internal("length", self.intraj.units, 1.0)
                         b.q[:] = myatoms.q

--- a/ipi/engine/motion/replay.py
+++ b/ipi/engine/motion/replay.py
@@ -75,7 +75,7 @@ class Replay(Motion):
                 metainfo = rr['comment'].split()
                 for i, word in enumerate(metainfo):
                     if word == 'Bead:':
-                        bead_map_list.append(int(metainfo[i+1]))
+                        bead_map_list.append(int(metainfo[i + 1]))
                 fdin.close()
             # check that beads are continuous (no files missing)
             if sorted(bead_map_list) != list(range(len(bead_map_list))):
@@ -85,7 +85,7 @@ class Replay(Motion):
                 )
             # sort the list of files according to their bead indices
             infilelist_sorted, _ = zip(*sorted(zip(infilelist, bead_map_list),
-                                       key = lambda t: t[1]))
+                                       key=lambda t: t[1]))
             self.rfile = [open(f, 'r') for f in infilelist_sorted]
         else:   # no wildcard
             self.rfile = open(self.intraj.value, "r")


### PR DESCRIPTION
It is possible now to use globs in a trajectory filename in replay mode.
If a filename with glob is provided, i-pi finds all files in working directory that match the provided pattern (Unix globs *?[] ), reads bead indices from them, assuming that these files have i-pi output format (XYZ or PDB). Then, it assigns the coordinates from these files to the corresponding beads.
Consistency of input is checked, only 'conservative' use (beads from 0 to Nbeads-1) is allowed.